### PR TITLE
Fix containers for talk and paper sections

### DIFF
--- a/research.html
+++ b/research.html
@@ -9,22 +9,26 @@
   <meta name="author" content="Jesse Liu">
 
   <title>Jesse Liu | Particle physicist, Grainger Fellow at UChicago </title>
-  <link rel="shortcut icon" type="image/png" href="img/icon.png"/>
+  <link rel="shortcut icon" type="image/png" href="img/icon.png" />
 
   <!-- Bootstrap Core CSS -->
-  <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/4.0.0-alpha.6/css/bootstrap.min.css" integrity="sha384-rwoIResjU2yc3z8GV/NPeZWAv56rSmLldC3R/AZzGRnGxQQKnKkoFVhFQhNUwEyJ" crossorigin="anonymous">
+  <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/4.0.0-alpha.6/css/bootstrap.min.css"
+    integrity="sha384-rwoIResjU2yc3z8GV/NPeZWAv56rSmLldC3R/AZzGRnGxQQKnKkoFVhFQhNUwEyJ" crossorigin="anonymous">
   <!-- Custom Fonts 
   <link href='https://fonts.googleapis.com/css?family=Open+Sans:300italic,400italic,600italic,700italic,800italic,400,300,600,700,800' rel='stylesheet' type='text/css'>-->
   <!-- Theme CSS -->
   <link href="css/mistphysics.min.css" rel="stylesheet">
   <!-- Font Awsome -->
-  <script src="https://use.fontawesome.com/d3df8c6bdc.js"></script> 
+  <script src="https://use.fontawesome.com/d3df8c6bdc.js"></script>
 </head>
+
 <body id="research">
 
   <nav class="navbar navbar-toggleable-sm navbar-inverse fixed-top">
     <div class="container">
-      <button class="navbar-toggler navbar-toggler-right" type="button" data-toggle="collapse" data-target="#navbarCollapse" aria-controls="navbarCollapse" aria-expanded="false" aria-label="Toggle navigation">
+      <button class="navbar-toggler navbar-toggler-right" type="button" data-toggle="collapse"
+        data-target="#navbarCollapse" aria-controls="navbarCollapse" aria-expanded="false"
+        aria-label="Toggle navigation">
         <span class="navbar-toggler-icon"></span>
       </button>
       <a class="navbar-brand" href="index.html">Jesse Liu</a>
@@ -59,10 +63,13 @@
     </div>
   </header>
 
-  <section id="themes">    
+  <section class="container"  id="themes">
     <div class="container section-header">
       <h2 class="section-title">Themes</h2>
-      <p class="lead">My research interests in particle physics concern designing experimental strategies to search for new physics beyond the Standard Model, probing the Higgs sector, supersymmetry and dark matter. New discovery frontiers are being opened by my work on the ATLAS detector and novel analysis strategies combined with phenomenological studies of dark matter and photon collider physics.</p>
+      <p class="lead">My research interests in particle physics concern designing experimental strategies to search for
+        new physics beyond the Standard Model, probing the Higgs sector, supersymmetry and dark matter. New discovery
+        frontiers are being opened by my work on the ATLAS detector and novel analysis strategies combined with
+        phenomenological studies of dark matter and photon collider physics.</p>
     </div>
     <div class="container section-content">
       <div class="row no-gutters">
@@ -70,342 +77,459 @@
           <article class="panel text-center">
             <i class="fa fa-4x fa-video-camera sr-icons"></i>
             <h3 class="panel-title">Experimental new physics searches </h3>
-            <p class="panel-text" style="text-align:left;">When Galileo upgraded his telescope to study Jupiter more closely, he did not anticipate unveiling new worlds in the process. He discovered the Galilean moons not necessarily because he was looking for them, but because his instruments could see them. Today, experimental searches for new physics continue this paradigm. I collaborate with scientists worldwide to refine and extend the capability of our instruments inspecting the microcosm and measure what we can see with greater precision. These advances in sensitivity could reveal phenomena we could never have anticipated. </p>          
+            <p class="panel-text" style="text-align:left;">When Galileo upgraded his telescope to study Jupiter more
+              closely, he did not anticipate unveiling new worlds in the process. He discovered the Galilean moons not
+              necessarily because he was looking for them, but because his instruments could see them. Today,
+              experimental searches for new physics continue this paradigm. I collaborate with scientists worldwide to
+              refine and extend the capability of our instruments inspecting the microcosm and measure what we can see
+              with greater precision. These advances in sensitivity could reveal phenomena we could never have
+              anticipated. </p>
           </article>
         </div>
         <div class="col-md-6 col-lg-6">
           <article class="panel text-center">
             <i class="fa fa-4x fa-cubes sr-icons"></i>
             <h3 class="panel-title">Supersymmetry and dark matter</h3>
-            <p class="panel-text" style="text-align:left;">A startling realisation of contemporary science is that 80% of the matter in our universe is dark. Supersymmetry predicts new particles of dark matter that could be discovered at the Large Hadron Collider. My PhD thesis interpreted collider and non-collider data to identify promising parameter space of supersymmetric dark matter (pMSSM). I then proposed and led analyses using the lowest momentum leptons in ATLAS to surpass nearly 2-decade old sensitivity (LEP) on scenarios favoured by such phenomenology studies (Higgsino dark matter and compressed sleptons). </p>          
+            <p class="panel-text" style="text-align:left;">A startling realisation of contemporary science is that 80%
+              of the matter in our universe is dark. Supersymmetry predicts new particles of dark matter that could be
+              discovered at the Large Hadron Collider. My PhD thesis interpreted collider and non-collider data to
+              identify promising parameter space of supersymmetric dark matter (pMSSM). I then proposed and led analyses
+              using the lowest momentum leptons in ATLAS to surpass nearly 2-decade old sensitivity (LEP) on scenarios
+              favoured by such phenomenology studies (Higgsino dark matter and compressed sleptons). </p>
           </article>
         </div>
         <div class="col-md-6 col-lg-6">
           <article class="panel text-center">
             <i class="fa fa-4x fa-fast-forward sr-icons"></i>
             <h3 class="panel-title">ATLAS and forward detectors</h3>
-            <p class="panel-text" style="text-align:left;">Particle detectors are our eyes to the microcosm. Their development, operation and performance underpin measurement and discovery capability. I led operational radiation damage studies of the ATLAS silicon tracker (SCT), crucial for identifying long-lived particles such as bottom quarks. I also designed new hardware-based algorithms to select dark matter signatures in real time with higher efficiency (Level 1 topological trigger). More recently, I am commissioning ATLAS Forward Proton (AFP) detectors, which measure the energy of intact protons, opening novel use of the LHC as a photon collider.</p>          
+            <p class="panel-text" style="text-align:left;">Particle detectors are our eyes to the microcosm. Their
+              development, operation and performance underpin measurement and discovery capability. I led operational
+              radiation damage studies of the ATLAS silicon tracker (SCT), crucial for identifying long-lived particles
+              such as bottom quarks. I also designed new hardware-based algorithms to select dark matter signatures in
+              real time with higher efficiency (Level 1 topological trigger). More recently, I am commissioning ATLAS
+              Forward Proton (AFP) detectors, which measure the energy of intact protons, opening novel use of the LHC
+              as a photon collider.</p>
           </article>
         </div>
         <div class="col-md-6 col-lg-6">
           <article class="panel text-center">
             <i class="fa fa-4x fa-bolt sr-icons"></i>
             <h3 class="panel-title">LHC as a photon collider</h3>
-            <p class="panel-text" style="text-align:left;">Quantum electrodynamics (QED) is the theory of everyday life, governing biochemical reactions to the optoelectronics displaying this text. Interestingly, the LHC offers unique opportunities to design new energy frontier tests of QED. Electromagnetic fields surrounding protons and heavy ions source an intense beam of high energy photons. These photons collide to make new particles, which may include supersymmetry and dark matter. Such collisions allow measurement of the initial state and missing momentum four-vector, which enhances a supersymmetry search strategy I proposed.</p>          
+            <p class="panel-text" style="text-align:left;">Quantum electrodynamics (QED) is the theory of everyday life,
+              governing biochemical reactions to the optoelectronics displaying this text. Interestingly, the LHC offers
+              unique opportunities to design new energy frontier tests of QED. Electromagnetic fields surrounding
+              protons and heavy ions source an intense beam of high energy photons. These photons collide to make new
+              particles, which may include supersymmetry and dark matter. Such collisions allow measurement of the
+              initial state and missing momentum four-vector, which enhances a supersymmetry search strategy I proposed.
+            </p>
           </article>
-        </div>   
+        </div>
         <div class="col-md-6 col-lg-6">
           <article class="panel text-center">
             <i class="fa fa-4x fa-puzzle-piece sr-icons"></i>
             <h3 class="panel-title">The origin of mass</h3>
-            <p class="panel-text" style="text-align:left;"> The Higgs boson is an experimental triumph of big science and its discovery allows new interactions to be probed. One tantalising prediction are Higgs bosons interacting with themselves. I am studying how to probe this Higgs self-coupling using challenging final states of four bottom quarks. I am developing strategies to exploit another never-before-seen phenomenon involving the quantum interference of two Higgs bosons. Experimentally observing and measuring these new phenomena is crucial for understanding electroweak symmetry breaking that endows all particles with mass.</p>          
+            <p class="panel-text" style="text-align:left;"> The Higgs boson is an experimental triumph of big science
+              and its discovery allows new interactions to be probed. One tantalising prediction are Higgs bosons
+              interacting with themselves. I am studying how to probe this Higgs self-coupling using challenging final
+              states of four bottom quarks. I am developing strategies to exploit another never-before-seen phenomenon
+              involving the quantum interference of two Higgs bosons. Experimentally observing and measuring these new
+              phenomena is crucial for understanding electroweak symmetry breaking that endows all particles with mass.
+            </p>
           </article>
         </div>
         <div class="col-md-6 col-lg-6">
           <article class="panel text-center">
             <i class="fa fa-4x fa-pencil sr-icons"></i>
             <h3 class="panel-title">Theoretical physics</h3>
-            <p class="panel-text" style="text-align:left;">In my master's essay, I developed the field theory of particles whose spin is labelled by an infinite tower of discrete quantum numbers (continuous-spin particles). These particles arise from the mathematics of spacetime symmetries in our universe (Poincaré group), and may be relevant for gravity and electromagnetism. In recent years, I have turned to phenomenology bridging theory with experiment. I have performed dark matter interpretations of data from the LHC, and I am currently devising new tests of QED and discovery strategies using photon collisions at the LHC. </p>          
+            <p class="panel-text" style="text-align:left;">In my master's essay, I developed the field theory of
+              particles whose spin is labelled by an infinite tower of discrete quantum numbers (continuous-spin
+              particles). These particles arise from the mathematics of spacetime symmetries in our universe (Poincaré
+              group), and may be relevant for gravity and electromagnetism. In recent years, I have turned to
+              phenomenology bridging theory with experiment. I have performed dark matter interpretations of data from
+              the LHC, and I am currently devising new tests of QED and discovery strategies using photon collisions at
+              the LHC. </p>
           </article>
         </div>
-       
+
       </div>
     </div>
   </section>
 
 
-  <section id="papers">    
+  <section class="container"  id="papers">
     <div class="container section-header flex-column">
       <h2 class="section-title">Papers</h2>
-      
-      
     </div>
+
     <div class="row section-content justify-content-center">
-    <div class="col-lg-8">
-    <article class="card">
-    <div class="card-block">
-      <p class="card-text">
+      <div class="col-lg-8">
+        <article class="card">
+          <div class="card-block">
+            <p class="card-text">
 
-      <h4>Phenomenology</h4>
-      <b>Photon collider search strategy for sleptons and dark matter at the LHC</b> <br>
-      Lydia Beresford and Jesse Liu<br>
-      <a href="https://arxiv.org/abs/1811.06465" target="_blank">arXiv:1811.06465</a> 
-      </p>
-      
-      <p class="text-faded"> 
-      <b>Analysing parameter space correlations of recent 13 TeV gluino and squark searches in the pMSSM</b><br>
-      Alan Barr and Jesse Liu<br>
-      <a href="https://arxiv.org/abs/1608.05379" target="_blank">arXiv:1608.05379</a>, <a href="https://link.springer.com/article/10.1140%2Fepjc%2Fs10052-017-4752-6" target="_blank"> Eur. Phys. J. C (2017) <b>77</b>: 202</a>
-      </p>
+              <h4>Phenomenology</h4>
+              <b>Photon collider search strategy for sleptons and dark matter at the LHC</b> <br>
+              Lydia Beresford and Jesse Liu<br>
+              <a href="https://arxiv.org/abs/1811.06465" target="_blank">arXiv:1811.06465</a>
+            </p>
 
-      <p class="text-faded">
-      <b>First interpretation of 13 TeV supersymmetry searches in the pMSSM</b><br>
-      Alan Barr and Jesse Liu<br>
-      <a href="https://arxiv.org/abs/1605.09502" target="_blank">arXiv:1605.09502</a><br>
-      <a href="http://www2.physics.ox.ac.uk/news/2016/06/06/supersymmetry-squeezed-at-the-high-energy-frontier" target="_blank">Oxford physics highlight</a>
-      </p>
+            <p class="text-faded">
+              <b>Analysing parameter space correlations of recent 13 TeV gluino and squark searches in the pMSSM</b><br>
+              Alan Barr and Jesse Liu<br>
+              <a href="https://arxiv.org/abs/1608.05379" target="_blank">arXiv:1608.05379</a>, <a
+                href="https://link.springer.com/article/10.1140%2Fepjc%2Fs10052-017-4752-6" target="_blank"> Eur. Phys.
+                J. C (2017) <b>77</b>: 202</a>
+            </p>
 
-      <h4>Analysis</h4>
-      <p class="text-faded">
-      <b>Search for electroweak production of  supersymmetric states in scenarios with compressed mass spectra at 13 TeV with the ATLAS detector</b><br>
-      ATLAS Collaboration (JL Editor and Lead Analyzer)<br>
-      <a href="https://arxiv.org/abs/1712.08119" target="_blank">arXiv:1712.08119</a>, <a href="https://journals.aps.org/prd/abstract/10.1103/PhysRevD.97.052010" target="_blank"> Phys. Rev. D <b>97</b> (2018) 052010</a>, <a href="https://atlas.web.cern.ch/Atlas/GROUPS/PHYSICS/PAPERS/SUSY-2016-25/">ATL-SUSY-2016-25</a><br>
-      <a href="https://atlas.cern/updates/physics-briefing/searching-supersymmetric-higgs-bosons-compressed-frontier" target="_blank">ATLAS Physics Briefing on Higgsinos</a>, 
-      <a href="https://atlas.cern/updates/physics-briefing/squeezing-sleptons-lhc" target="_blank">Briefing on sleptons</a></li>, 
-       <a href="https://www2.physics.ox.ac.uk/research/atlas/highlights/oxford-team-probes-for-higgs-boson-partners" target="_blank">Oxford physics Highlight</a>
-      </p>
+            <p class="text-faded">
+              <b>First interpretation of 13 TeV supersymmetry searches in the pMSSM</b><br>
+              Alan Barr and Jesse Liu<br>
+              <a href="https://arxiv.org/abs/1605.09502" target="_blank">arXiv:1605.09502</a><br>
+              <a href="http://www2.physics.ox.ac.uk/news/2016/06/06/supersymmetry-squeezed-at-the-high-energy-frontier"
+                target="_blank">Oxford physics highlight</a>
+            </p>
 
-      <h4>Detector</h4>
-      <p class="text-faded">
-      <b>In Situ Radiation Damage studies of Optoelectronics in the ATLAS SemiConductor Tracker
-      </b><br>
-      Ian Dawson, Bruce Gallop, Jesse Liu, Peter Miyagawa, Peter Phillips, Gavin Pownall, Dave Robinson and Anthony Weidberg <br>
-      Accepted Journal of Instrumentation (2019)<br>
-      Preliminary results: <a href="https://atlas.web.cern.ch/Atlas/GROUPS/PHYSICS/PLOTS/SCT-2018-003/">SCT-2018-003</a>, <a href="https://atlas.web.cern.ch/Atlas/GROUPS/PHYSICS/PLOTS/SCT-2017-003/">SCT-2017-003</a>, <a href="https://atlas.web.cern.ch/Atlas/GROUPS/PHYSICS/PLOTS/SCT-2016-002/">SCT-2016-002</a>
-      </p>
+            <h4>Analysis</h4>
+            <p class="text-faded">
+              <b>Search for electroweak production of supersymmetric states in scenarios with compressed mass spectra at
+                13 TeV with the ATLAS detector</b><br>
+              ATLAS Collaboration (JL Editor and Lead Analyzer)<br>
+              <a href="https://arxiv.org/abs/1712.08119" target="_blank">arXiv:1712.08119</a>, <a
+                href="https://journals.aps.org/prd/abstract/10.1103/PhysRevD.97.052010" target="_blank"> Phys. Rev. D
+                <b>97</b> (2018) 052010</a>, <a
+                href="https://atlas.web.cern.ch/Atlas/GROUPS/PHYSICS/PAPERS/SUSY-2016-25/">ATL-SUSY-2016-25</a><br>
+              <a href="https://atlas.cern/updates/physics-briefing/searching-supersymmetric-higgs-bosons-compressed-frontier"
+                target="_blank">ATLAS Physics Briefing on Higgsinos</a>,
+              <a href="https://atlas.cern/updates/physics-briefing/squeezing-sleptons-lhc" target="_blank">Briefing on
+                sleptons</a></li>,
+              <a href="https://www2.physics.ox.ac.uk/research/atlas/highlights/oxford-team-probes-for-higgs-boson-partners"
+                target="_blank">Oxford physics Highlight</a>
+            </p>
 
-      I am author on all papers signed 'ATLAS Collaboration'.
-      Find a full list of my papers at inspire:
-      <div class="linknav">
-        <p><br>
-        <a class="btn inspire" href="http://inspirehep.net/search?p=exactauthor%3AJesse.Liu.1&sf=earliestdate" target="_blank">all</a>
-        <a class="btn arxiv" href="http://inspirehep.net/search?p=exactauthor%3AJesse.Liu.1+65017a%3A%22Phenomenology-HEP%22" target="_blank">hep-ph</a>
-      </p>
+            <h4>Detector</h4>
+            <p class="text-faded">
+              <b>In Situ Radiation Damage studies of Optoelectronics in the ATLAS SemiConductor Tracker
+              </b><br>
+              Ian Dawson, Bruce Gallop, Jesse Liu, Peter Miyagawa, Peter Phillips, Gavin Pownall, Dave Robinson and
+              Anthony Weidberg <br>
+              Accepted Journal of Instrumentation (2019)<br>
+              Preliminary results: <a
+                href="https://atlas.web.cern.ch/Atlas/GROUPS/PHYSICS/PLOTS/SCT-2018-003/">SCT-2018-003</a>, <a
+                href="https://atlas.web.cern.ch/Atlas/GROUPS/PHYSICS/PLOTS/SCT-2017-003/">SCT-2017-003</a>, <a
+                href="https://atlas.web.cern.ch/Atlas/GROUPS/PHYSICS/PLOTS/SCT-2016-002/">SCT-2016-002</a>
+            </p>
+
+            I am author on all papers signed 'ATLAS Collaboration'.
+            Find a full list of my papers at inspire:
+            <div class="linknav">
+              <p><br>
+                <a class="btn inspire" href="http://inspirehep.net/search?p=exactauthor%3AJesse.Liu.1&sf=earliestdate"
+                  target="_blank">all</a>
+                <a class="btn arxiv"
+                  href="http://inspirehep.net/search?p=exactauthor%3AJesse.Liu.1+65017a%3A%22Phenomenology-HEP%22"
+                  target="_blank">hep-ph</a>
+              </p>
+            </div>
+
+          </div>
+        </article>
       </div>
-      
     </div>
-    </article>
-    </div>
-  </div>
-</section>
+  </section>
 
-  <section id="talks">    
-    <div class="container section-header flex-column">
+  <section class="container" id="talks">
+    <div class="section-header flex-column">
       <h2 class="section-title">Talks</h2>
-      
+    </div>
+
+    <div class="row section-content justify-content-center">
+      <div class="col-lg-8">
+        <article class="card">
+          <div class="card-block">
+            <div class="row">
+              <div class="col-md-4">
+                <figure class="figure">
+                  <img src="img/ichep_compressed_ewk.png" class="figure-img img-fluid" alt="ICHEP 2018, Seoul">
+                  <figcaption class="figure-caption">ICHEP 2018, Seoul</figcaption>
+                </figure>
+              </div>
+              <div class="col-md-4">
+                <figure class="figure">
+                  <img src="img/softInterpretChallenge.png" class="figure-img img-fluid" alt="Dalitz Seminar, Oxford">
+                  <figcaption class="figure-caption">Dalitz Seminar, Oxford</figcaption>
+                </figure>
+              </div>
+              <div class="col-md-4">
+                <figure class="figure">
+                  <img src="img/first13TeVpMSSM.png" class="figure-img img-fluid"
+                    alt="LHC Reinterpretation Workshop, CERN">
+                  <figcaption class="figure-caption">LHC Reinterpretation Workshop, CERN</figcaption>
+                </figure>
+              </div>
+            </div>
+            <br>
+            <h4>Invited Seminars</h4>
+
+            <p class="card-text">
+              <b>University of Cambridge, UK</b>, <a href="http://www.talks.cam.ac.uk/talk/index/119656"
+                target="_blank">Cavendish HEP Seminar</a>, 19 Feb 2019
+              <br>
+              <b>LBNL, University of California, Berkeley, USA</b>, <a
+                href="http://physics.lbl.gov/rpm/index.php/event/jesse-liu-u-oxford-tba/" target="_blank">Research
+                Progress Meeting Seminar</a>, 20 Nov 2018
+              <br>
+              'New frontiers in LHC discovery strategies' <br>
+            </p>
+
+            <p class="text-faded">
+              <b>SLAC, Stanford University, USA </b>, <a
+                href="https://theory.slac.stanford.edu/events/epp-theory-seminar-jesse-liu-supersymmetry-closing-the-gaps-lhc-sensitivity"
+                target="_blank">Joint Theory–Experiment Seminar</a>, 20 Apr 2018 <br>
+              <b>Perimeter Institute for Theoretical Physics, Canada</b>, BSM Seminar, 17 Apr 2018<br>
+              <b>University of California, Santa Cruz, USA</b>, <a
+                href="https://calendar.google.com/calendar/event?eid=MHRwMDRjazI0MWZ0djdqNTVxbGhucjc2Y2NfMjAxODA0MTBUMjEzMDAwWiB1Y3NjLmVkdV83ZXVjaWdoaTljdnVsMDEyZXFoMHA2bWNpMEBn&ctz=America/Los_Angeles"
+                target="_blank">SCIPP Seminar</a>, 10 Apr 2018<br>
+              'Supersymmetry: closing the gaps at the LHC'
+            </p>
+
+            <p class="text-faded">
+              <b>University of Oxford, UK</b>, <a
+                href="https://www2.physics.ox.ac.uk/research/seminars/series/dalitz-seminar-in-fundamental-physics?date=2017"
+                target="_blank">Dalitz Seminar in Fundamental Physics</a>, 19 Jan 2017<br>
+              <b>University of Cambridge, UK</b>, <a href="http://talks.cam.ac.uk/talk/index/69957"
+                target="_blank">Joint DAMTP–Cavendish Seminar</a>, 13 Jan 2017<br>
+              'Phenomenological interpretations of SUSY searches'
+            </p>
+
+            <h4>Conference Presentations</h4>
+            <p>
+              <a href="https://conference.ippp.dur.ac.uk/event/723/sessions/949" target="_blank">Young Experimentalists
+                and Theorists Institute, Durham, UK</a>, 8 Jan 2019<br>
+              <a href="https://indico.cern.ch/event/754941/contributions/3245054/" target="_blank">LHC Forward Physics
+                Workshop, CERN, Switzerland</a>, 18 Dec 2018<br>
+              'Photon collider opportunities for new physics: SUSY and dark matter'
+            </p>
+
+            <p>
+              <a href="https://indico.cern.ch/event/689399/contributions/3005438/" target="_blank">SUSY 2018, Barcelona,
+                Spain</a>, 23 Jul 2018<br>
+              'Reconstruction techniques in ATLAS SUSY searches'
+            </p>
+            <p>
+              <a href="https://indico.cern.ch/event/686555/contributions/2974969/" target="_blank">ICHEP 2018, Seoul,
+                South Korea</a>, 6 Jul 2018<br>
+              <a href="https://indico.cern.ch/event/686555/contributions/3028095/" target="_blank">ICHEP Prize Talk</a>,
+              11 Jul 2018<br>
+              'Innovative strategies in compressed electroweak SUSY searches'
+            </p>
+
+            <p>
+              <a href="https://indico.cern.ch/event/669891/contributions/2897835/" target="_blank">DM@LHC 2018,
+                Heidelberg, Germany</a>, 5 Apr 2018<br>
+              <a href="https://indico.cern.ch/event/695164/contributions/2922819/" target="_blank">Institute of Physics
+                Conference 2018, Bristol, UK</a>, 27 Mar 2018<br><a
+                href="https://conference.ippp.dur.ac.uk/event/630/contributions/3526/" target="_blank">Young Theorists
+                Forum 2018, Durham, UK</a>, 10 Jan 2018<br>
+              'Opening the soft lepton frontier for new physics at the LHC'
+            </p>
+
+            <p>
+              <a href="http://conference.ippp.dur.ac.uk/event/560/session/0/contribution/1" target="_blank">Young
+                Theorists Forum 2017, Durham, UK</a>, 11 Jan 2017<br>
+              <a href="https://indico.cern.ch/event/571190/timetable/#28-phase-space-correlations-of"
+                target="_blank">2nd LHC BSM Reinterpretation Workshop, CERN, Switzerland</a>, 14 Dec 2016<br>
+              'Parameter space correlations of 13 TeV SUSY searches'
+            </p>
+
+            <p>
+              <a href="https://sites.google.com/site/busstepp2016/program" target="_blank">BUSSTEPP 2016, Manchester,
+                UK</a>, 31 Aug 2016<br>
+              <a href="https://indico.cern.ch/event/525142/contributions/2196603/" target="_blank">1st LHC BSM
+                Reinterpretation Workshop, CERN, Switzerland</a>, 17 Jun 2016<br>
+              'Phenomenological interpretations of strong SUSY searches'
+            </p>
+
+            <h4>ATLAS Plenaries</h4>
+
+            <p>
+              <a href="https://indico.cern.ch/event/803794/#13-photon-collider-susydm-sear" target="_blank">ATLAS UK
+                Exotics SUSY Meeting, Cambridge, UK</a>, 11 Apr 2019<br>
+              'Photon collider SUSY/DM searches with forward proton detectors'
+            </p>
+
+            <p>
+              <a href="https://indico.cern.ch/event/739415/#10-news-from-recent-conference" target="_blank">ATLAS SUSY
+                Group Plenary, CERN, Switzerland</a>, 19 Jul 2018<br>
+              'Physics highlights at recent international conferences'
+            </p>
+
+            <p>
+              <a href="https://indico.cern.ch/event/710748/contributions/3004583/" target="_blank">ATLAS Exotics
+                Workshop, Rome, Italy</a>, 29 May 2018<br>
+              'Opening the monojet + soft lepton frontier for dark matter' (poster)
+            </p>
+
+            <p>
+              <a href="https://indico.cern.ch/event/648945/#25-latest-susy-results" target="_blank">ATLAS Week Plenary,
+                CERN, Switzerland</a>, 21 Feb 2018<br>
+              'Latest SUSY results'
+            </p>
+
+            <p>
+              <a href="https://indico.cern.ch/event/676709/" target="_blank">ATLAS Analysis Open Presentation, CERN,
+                Switzerland</a>, 1 Nov 2017<br>
+              'Search for Higgsinos and compressed sleptons'
+            </p>
+
+            <p>
+              <a href="https://indico.cern.ch/event/605722/timetable/#268-pmssm-scans" target="_blank">ATLAS Joint
+                Exotics-SUSY Workshop, Bucharest, Romania</a>, 12 May 2017<br>
+              'Phenomenological studies of ATLAS SUSY searches'
+            </p>
+
+            <p>
+              <a href="https://indico.cern.ch/event/567771/contributions/2402620/" target="_blank">ATLAS UK Meeting,
+                University of Liverpool, UK</a>, 5 Jan 2017 <br>
+              'New innovative ideas and analyses in supersymmetry'
+            </p>
+
+            <p>
+              <a href="https://indico.cern.ch/event/402291/#8-sct-and-id-gen" target="_blank">ATLAS Week Plenary, CERN,
+                Switzerland</a>, 17 Oct 2016 <br>
+              'Semiconductor tracker: status report'
+            </p>
+
+          </div>
+        </article>
+      </div>
+    </div>
+  </section>
+
+  <section class="container section-content">
+    <div class="section-header">
+      <h3>Photon collider searches for new physics</h3>
+      <p>Using the LHC as a photon collider</p>
+    </div>
+
+    <div class="row section-content justify-content-center">
+      <div class="col-lg-8">
+        <article class="card">
+          <img class="card-img-top img-responsive center-block" src="img/slepton_photon_collider.png"
+            alt="Slepton sensitivity with photon collider">
+          <div class="card-block">
+            <h4 class="card-title">Photon collider search strategy for sleptons and dark matter at the LHC</h4>
+            <h6 class="card-subtitle text-muted">Lydia Beresford and Jesse Liu</h6>
+            <h6 class="card-subtitle text-muted">arXiv:1811.06465</h6>
+            <p class="card-text">When LHC beams cross, photons from the proton electromagnetic fields can collide to
+              make new particles. The so-called ultra-peripheral events are exceptionally clean, with only QED
+              interactions involved at production. The protons remain intact, travel down the beampipe, and are detected
+              by very forward detectors. This allows us to reconstruct initital state information and the full missing
+              momentum 4-vector &mdash; impossible in usual head-on collisions. My collaborator and I exploit these
+              unique features to propose a search strategy that uncovers the blind spot where the slepton is 15 to 60
+              GeV heavier than the dark matter. Remarkably, this is the region favoured by non-collider data from
+              cosmology and muon magnetic moment measurements. </p>
+          </div>
+        </article>
+      </div>
+
+    </div>
+  </section>
+
+  <section class="container section-content" id="lhc-interp">
+    <div class="section-header">
+      <h3>The soft lepton frontier for new physics</h3>
+      <p>Analysing data collected by ATLAS to search for Higgsinos and compressed sleptons</p>
     </div>
     <div class="row section-content justify-content-center">
-    <div class="col-lg-8">
-    <article class="card">
-    <div class="card-block">
-      <div class="row"> 
-        <div class="col-md-4">
-          <figure class="figure">
-            <img src="img/ichep_compressed_ewk.png" class="figure-img img-fluid" alt="ICHEP 2018, Seoul">
-            <figcaption class="figure-caption">ICHEP 2018, Seoul</figcaption>
-          </figure>          
-        </div>
-        <div class="col-md-4">
-          <figure class="figure">
-            <img src="img/softInterpretChallenge.png" class="figure-img img-fluid" alt="Dalitz Seminar, Oxford">
-            <figcaption class="figure-caption">Dalitz Seminar, Oxford</figcaption>
-          </figure>          
-        </div>
-        <div class="col-md-4">
-          <figure class="figure">
-            <img src="img/first13TeVpMSSM.png" class="figure-img img-fluid" alt="LHC Reinterpretation Workshop, CERN">
-            <figcaption class="figure-caption">LHC Reinterpretation Workshop, CERN</figcaption>
-          </figure>          
-        </div>
+      <div class="col-lg-8">
+        <article class="card">
+          <img class="card-img-top img-responsive center-block" src="img/ATLAS_SUSY_EWSummary_higgsino.png"
+            alt="ATLAS SUSY EWSummary higgsino">
+          <div class="card-block">
+            <h4 class="card-title">Search for electroweak production of supersymmetric states in scenarios with
+              compressed mass spectra at sqrt(s)=13 TeV with the ATLAS detector</h4>
+            <h6 class="card-subtitle text-muted">ATLAS Collaboration</h6>
+            <h6 class="card-subtitle text-muted">arXiv:1712.08119, Phys. Rev. D 97 (2018) 052010</h6>
+
+            <p class="card-text">I had the privilege of collaborating with an excellent international analysis team for
+              this project.
+              This work presents the first hadron collider sensitivity to some of the most challenging but sought-after
+              scenarios of natural supersymmetry and dark matter involving so-called compressed mass spectra, namely
+              Higgsinos and compressed sleptons. We probed these using the two leptons and missing transverse momentum
+              final state, which were striking blind spots before Run 2 of the LHC. Soft lepton reconstruction down to 4
+              GeV &mdash; among the lowest used by the ATLAS Experiment &mdash; was crucial in opening world-leading
+              sensitivity that surpasses nearly two-decade old LEP limits. </p>
+
+          </div>
+        </article>
       </div>
-      <br>
-      <h4>Invited Seminars</h4>
-
-      <p class="card-text">
-      <b>University of Cambridge, UK</b>, <a href="http://www.talks.cam.ac.uk/talk/index/119656" target="_blank">Cavendish HEP Seminar</a>, 19 Feb 2019
-      <br>
-      <b>LBNL, University of California, Berkeley, USA</b>, <a href="http://physics.lbl.gov/rpm/index.php/event/jesse-liu-u-oxford-tba/" target="_blank">Research Progress Meeting Seminar</a>, 20 Nov 2018
-      <br>
-      'New frontiers in LHC discovery strategies' <br>
-      </p>
-
-      <p class="text-faded">
-      <b>SLAC, Stanford University, USA </b>, <a href="https://theory.slac.stanford.edu/events/epp-theory-seminar-jesse-liu-supersymmetry-closing-the-gaps-lhc-sensitivity" target="_blank">Joint Theory–Experiment Seminar</a>, 20 Apr 2018 <br>
-      <b>Perimeter Institute for Theoretical Physics, Canada</b>, BSM Seminar, 17 Apr 2018<br>
-      <b>University of California, Santa Cruz, USA</b>, <a href="https://calendar.google.com/calendar/event?eid=MHRwMDRjazI0MWZ0djdqNTVxbGhucjc2Y2NfMjAxODA0MTBUMjEzMDAwWiB1Y3NjLmVkdV83ZXVjaWdoaTljdnVsMDEyZXFoMHA2bWNpMEBn&ctz=America/Los_Angeles" target="_blank">SCIPP Seminar</a>, 10 Apr 2018<br>
-      'Supersymmetry: closing the gaps at the LHC'
-      </p>
-
-      <p class="text-faded">
-      <b>University of Oxford, UK</b>, <a href="https://www2.physics.ox.ac.uk/research/seminars/series/dalitz-seminar-in-fundamental-physics?date=2017" target="_blank">Dalitz Seminar in Fundamental Physics</a>, 19 Jan 2017<br>
-      <b>University of Cambridge, UK</b>, <a href="http://talks.cam.ac.uk/talk/index/69957" target="_blank">Joint DAMTP–Cavendish Seminar</a>, 13 Jan 2017<br>
-      'Phenomenological interpretations of SUSY searches'
-      </p>
-
-      <h4>Conference Presentations</h4>
-      <p>
-        <a href="https://conference.ippp.dur.ac.uk/event/723/sessions/949" target="_blank">Young Experimentalists and Theorists Institute, Durham, UK</a>, 8 Jan 2019<br>
-        <a href="https://indico.cern.ch/event/754941/contributions/3245054/" target="_blank">LHC Forward Physics Workshop, CERN, Switzerland</a>, 18 Dec 2018<br>
-      'Photon collider opportunities for new physics: SUSY and dark matter'
-      </p>
-
-      <p>
-        <a href="https://indico.cern.ch/event/689399/contributions/3005438/" target="_blank">SUSY 2018, Barcelona, Spain</a>, 23 Jul 2018<br>
-      'Reconstruction techniques in ATLAS SUSY searches'
-      </p>
-      <p>
-        <a href="https://indico.cern.ch/event/686555/contributions/2974969/" target="_blank">ICHEP 2018, Seoul, South Korea</a>, 6 Jul 2018<br>
-        <a href="https://indico.cern.ch/event/686555/contributions/3028095/" target="_blank">ICHEP Prize Talk</a>, 11 Jul 2018<br>
-      'Innovative strategies in compressed electroweak SUSY searches'
-      </p>
-
-      <p>
-        <a href="https://indico.cern.ch/event/669891/contributions/2897835/" target="_blank">DM@LHC 2018, Heidelberg, Germany</a>, 5 Apr 2018<br>
-        <a href="https://indico.cern.ch/event/695164/contributions/2922819/" target="_blank">Institute of Physics Conference 2018, Bristol, UK</a>, 27 Mar 2018<br><a href="https://conference.ippp.dur.ac.uk/event/630/contributions/3526/" target="_blank">Young Theorists Forum 2018, Durham, UK</a>, 10 Jan 2018<br>
-      'Opening the soft lepton frontier for new physics at the LHC'
-      </p>
-
-      <p>
-        <a href="http://conference.ippp.dur.ac.uk/event/560/session/0/contribution/1" target="_blank">Young Theorists Forum 2017, Durham, UK</a>, 11 Jan 2017<br>
-        <a href="https://indico.cern.ch/event/571190/timetable/#28-phase-space-correlations-of" target="_blank">2nd LHC BSM Reinterpretation Workshop, CERN, Switzerland</a>, 14 Dec 2016<br>
-      'Parameter space correlations of 13 TeV SUSY searches'
-      </p>
-
-      <p>
-        <a href="https://sites.google.com/site/busstepp2016/program" target="_blank">BUSSTEPP 2016, Manchester, UK</a>, 31 Aug 2016<br>
-        <a href="https://indico.cern.ch/event/525142/contributions/2196603/" target="_blank">1st LHC BSM Reinterpretation Workshop, CERN, Switzerland</a>, 17 Jun 2016<br>
-        'Phenomenological interpretations of strong SUSY searches'
-      </p>
-
-      <h4>ATLAS Plenaries</h4>
-
-      <p>
-       <a href="https://indico.cern.ch/event/803794/#13-photon-collider-susydm-sear" target="_blank">ATLAS UK Exotics SUSY Meeting, Cambridge, UK</a>, 11 Apr 2019<br>
-      'Photon collider SUSY/DM searches with forward proton detectors'
-      </p>
-
-      <p>
-       <a href="https://indico.cern.ch/event/739415/#10-news-from-recent-conference" target="_blank">ATLAS SUSY Group Plenary, CERN, Switzerland</a>, 19 Jul 2018<br>
-      'Physics highlights at recent international conferences'
-      </p>
-
-      <p>
-      <a href="https://indico.cern.ch/event/710748/contributions/3004583/" target="_blank">ATLAS Exotics Workshop, Rome, Italy</a>, 29 May 2018<br>
-      'Opening the monojet + soft lepton frontier for dark matter' (poster)
-      </p>
-
-      <p>
-      <a href="https://indico.cern.ch/event/648945/#25-latest-susy-results" target="_blank">ATLAS Week Plenary, CERN, Switzerland</a>, 21 Feb 2018<br>
-      'Latest SUSY results'
-      </p>
-
-      <p>
-      <a href="https://indico.cern.ch/event/676709/" target="_blank">ATLAS Analysis Open Presentation, CERN, Switzerland</a>, 1 Nov 2017<br>
-      'Search for Higgsinos and compressed sleptons'
-      </p>
-
-      <p>
-      <a href="https://indico.cern.ch/event/605722/timetable/#268-pmssm-scans" target="_blank">ATLAS Joint Exotics-SUSY Workshop, Bucharest, Romania</a>, 12 May 2017<br>
-      'Phenomenological studies of ATLAS SUSY searches'
-      </p>
-
-      <p>
-      <a href="https://indico.cern.ch/event/567771/contributions/2402620/" target="_blank">ATLAS UK Meeting, University of Liverpool, UK</a>, 5 Jan 2017 <br>
-      'New innovative ideas and analyses in supersymmetry'
-      </p>
-
-      <p>
-      <a href="https://indico.cern.ch/event/402291/#8-sct-and-id-gen" target="_blank">ATLAS Week Plenary, CERN, Switzerland</a>, 17 Oct 2016 <br>
-      'Semiconductor tracker: status report'
-      </p>
 
     </div>
-    </article>
+  </section>
+
+
+
+  <section class="container section-content" id="lhc-interp">
+    <div class="section-header">
+      <h3>The LHC interpretation challenge</h3>
+      <p>How do we interpret the results of searches pursued by LHC experiments?</p>
     </div>
-  </div>
-</section>
+    <div class="row section-content">
+      <div class="col-lg-6">
+        <article class="card">
 
-    <section class="container section-content">
-      <div class="section-header">
-        <h3>Photon collider searches for new physics</h3>
-        <p>Using the LHC as a photon collider</p>
-      </div>      
-      <div class="row section-content justify-content-center">
-        <div class="col-lg-8">
-          <article class="card">
-            <img class="card-img-top img-responsive center-block" src="img/slepton_photon_collider.png" alt="Slepton sensitivity with photon collider">
-            <div class="card-block">
-            <h4 class="card-title">Photon collider search strategy for sleptons and dark matter at the LHC</h4>
-             <h6 class="card-subtitle text-muted">Lydia Beresford and Jesse Liu</h6>
-             <h6 class="card-subtitle text-muted">arXiv:1811.06465</h6>
-              <p class="card-text">When LHC beams cross, photons from the proton electromagnetic fields can collide to make new particles. The so-called ultra-peripheral events are exceptionally clean, with only QED interactions involved at production. The protons remain intact, travel down the beampipe, and are detected by very forward detectors. This allows us to reconstruct initital state information and the full missing momentum 4-vector &mdash; impossible in usual head-on collisions. My collaborator and I exploit these unique features to propose a search strategy that uncovers the blind spot where the slepton is 15 to 60 GeV heavier than the dark matter. Remarkably, this is the region favoured by non-collider data from cosmology and muon magnetic moment measurements. </p>
-            </div>           
-          </article>
-        </div>
-                 
-      </div>        
-    </section>
+          <div class="card-block">
+            <h4 class="card-title">Analysing parameter space correlations of recent 13 TeV gluino and squark searches in
+              the pMSSM</h4>
+            <h6 class="card-subtitle text-muted">Alan Barr and Jesse Liu</h6>
+            <h6 class="card-subtitle text-muted">arXiv:1608.05379, Eur. Phys. J. C (2017) 77: 202.</h6>
+            <img src="img/dm_lhc_dd.png" class="img-responsive center-block" alt="Dark matter LHC and direct detection">
+            <p class="card-text">LHC supersymmetry searches are designed around <em>simplified models</em>. These
+              capture the key experimental kinematic (e.g. jet energies) and structural (e.g. number of electrons)
+              features in a collision. But beyond this model-independent characterisation of signatures, they are toy
+              models for interpretation. If our universe were supersymmetric, how do the sensitivity of these searches
+              map onto realistic scenarios? This is the LHC <em>interpretation challenge</em>, and addressing this is
+              the purpose of our paper.</p>
 
-    <section class="container section-content" id="lhc-interp">
-      <div class="section-header">
-        <h3>The soft lepton frontier for new physics</h3>
-        <p>Analysing data collected by ATLAS to search for Higgsinos and compressed sleptons</p>
-      </div>      
-      <div class="row section-content justify-content-center">
-        <div class="col-lg-8">
-          <article class="card">
-            <img class="card-img-top img-responsive center-block" src="img/ATLAS_SUSY_EWSummary_higgsino.png" alt="ATLAS SUSY EWSummary higgsino">
-            <div class="card-block">
-              <h4 class="card-title">Search for electroweak production of supersymmetric states in scenarios with compressed mass spectra at sqrt(s)=13 TeV with the ATLAS detector</h4>
-              <h6 class="card-subtitle text-muted">ATLAS Collaboration</h6> 
-              <h6 class="card-subtitle text-muted">arXiv:1712.08119, Phys. Rev. D 97 (2018) 052010</h6> 
-              
-              <p class="card-text">I had the privilege of collaborating with an excellent international analysis team for this project. 
-              This work presents the first hadron collider sensitivity to some of the most challenging but sought-after scenarios of natural supersymmetry and dark matter involving so-called compressed mass spectra, namely Higgsinos and compressed sleptons. We probed these using the two leptons and missing transverse momentum final state, which were striking blind spots before Run 2 of the LHC. Soft lepton reconstruction down to 4 GeV &mdash; among the lowest used by the ATLAS Experiment &mdash; was crucial in opening world-leading sensitivity that surpasses nearly two-decade old LEP limits. </p>
-             
-            </div>           
-          </article>
-        </div>
-                 
-      </div>        
-    </section>
+          </div>
+        </article>
+      </div>
+      <div class="col-lg-6">
+        <article class="card">
 
+          <div class="card-block">
+            <h4 class="card-title">First interpretation of 13 TeV supersymmetry searches in the pMSSM</h4>
+            <h6 class="card-subtitle text-muted">Alan Barr and Jesse Liu</h6>
+            <h6 class="card-subtitle text-muted">arXiv:1605.09502</h6>
 
+            <img src="img/susy_13tev.png" class="img-responsive center-block" alt="Squarks and gluinos early 13 TeV">
+            <p>This is the first interpretation of six early 13 TeV ATLAS searches for supersymmetry within the
+              19-parameter 'phenomenological MSSM' theoretical framework. This work was referenced by <a
+                href="https://indico.cern.ch/event/443176/contributions/2195561/" target="_blank"> several</a> <a
+                href="https://indico.cern.ch/event/442390/timetable/#149-pmssm-studies-with-atlas-a"
+                target="_blank">speakers</a> at major summer conferences, and used by the <a
+                href="http://www.susy-ai.org/" target="_blank">SUSY-AI Online</a> effort.</p>
 
-    <section class="container section-content" id="lhc-interp">
-      <div class="section-header">
-        <h3>The LHC interpretation challenge</h3>
-        <p>How do we interpret the results of searches pursued by LHC experiments?</p>
-      </div>      
-      <div class="row section-content">
-        <div class="col-lg-6">
-          <article class="card">
-            
-            <div class="card-block">
-              <h4 class="card-title">Analysing parameter space correlations of recent 13 TeV gluino and squark searches in the pMSSM</h4>
-              <h6 class="card-subtitle text-muted">Alan Barr and Jesse Liu</h6> 
-              <h6 class="card-subtitle text-muted">arXiv:1608.05379, Eur. Phys. J. C (2017) 77: 202.</h6>              
-              <img src="img/dm_lhc_dd.png" class="img-responsive center-block" alt="Dark matter LHC and direct detection">
-              <p class="card-text">LHC supersymmetry searches are designed around <em>simplified models</em>. These capture the key experimental kinematic (e.g. jet energies) and structural (e.g. number of electrons) features in a collision. But beyond this model-independent characterisation of signatures, they are toy models for interpretation. If our universe were supersymmetric, how do the sensitivity of these searches map onto realistic scenarios? This is the LHC <em>interpretation challenge</em>, and addressing this is the purpose of our paper.</p>
-                          
-            </div>           
-          </article>
-        </div>
-        <div class="col-lg-6">
-          <article class="card">
-            
-            <div class="card-block">
-              <h4 class="card-title">First interpretation of 13 TeV supersymmetry searches in the pMSSM</h4>
-              <h6 class="card-subtitle text-muted">Alan Barr and Jesse Liu</h6>
-              <h6 class="card-subtitle text-muted">arXiv:1605.09502</h6>
-              
-              <img src="img/susy_13tev.png" class="img-responsive center-block" alt="Squarks and gluinos early 13 TeV">
-              <p>This is the first interpretation of six early 13 TeV ATLAS searches for supersymmetry within the 19-parameter 'phenomenological MSSM' theoretical framework. This work was referenced by <a href="https://indico.cern.ch/event/443176/contributions/2195561/" target="_blank"> several</a> <a href="https://indico.cern.ch/event/442390/timetable/#149-pmssm-studies-with-atlas-a" target="_blank">speakers</a> at major summer conferences, and used by the <a href="http://www.susy-ai.org/" target="_blank">SUSY-AI Online</a> effort.</p>
-                           
-            </div>           
-          </article>
-        </div>         
-      </div>        
-    </section>     
+          </div>
+        </article>
+      </div>
+    </div>
+  </section>
   </section>
 
 
   <!-- jQuery -->
-  <script src="https://code.jquery.com/jquery-3.1.1.slim.min.js" integrity="sha384-A7FZj7v+d/sdmMqp/nOQwliLvUsJfDHW+k9Omg/a/EheAdgtzNs3hpfag6Ed950n" crossorigin="anonymous"></script>
-   <!-- Tether io -->
-  <script src="https://cdnjs.cloudflare.com/ajax/libs/tether/1.4.0/js/tether.min.js" integrity="sha384-DztdAPBWPRXSA/3eYEEUWrWCy7G5KFbe8fFjk5JAIxUYHKkDx6Qin1DkWx51bBrb" crossorigin="anonymous"></script>
+  <script src="https://code.jquery.com/jquery-3.1.1.slim.min.js"
+    integrity="sha384-A7FZj7v+d/sdmMqp/nOQwliLvUsJfDHW+k9Omg/a/EheAdgtzNs3hpfag6Ed950n"
+    crossorigin="anonymous"></script>
+  <!-- Tether io -->
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/tether/1.4.0/js/tether.min.js"
+    integrity="sha384-DztdAPBWPRXSA/3eYEEUWrWCy7G5KFbe8fFjk5JAIxUYHKkDx6Qin1DkWx51bBrb"
+    crossorigin="anonymous"></script>
   <!-- Bootstrap Core JavaScript -->
-  <script src="https://maxcdn.bootstrapcdn.com/bootstrap/4.0.0-alpha.6/js/bootstrap.min.js" integrity="sha384-vBWWzlZJ8ea9aCX4pEW3rVHjgjt7zpkNpZk+02D9phzyeVkE+jo0ieGizqPLForn" crossorigin="anonymous"></script>
+  <script src="https://maxcdn.bootstrapcdn.com/bootstrap/4.0.0-alpha.6/js/bootstrap.min.js"
+    integrity="sha384-vBWWzlZJ8ea9aCX4pEW3rVHjgjt7zpkNpZk+02D9phzyeVkE+jo0ieGizqPLForn"
+    crossorigin="anonymous"></script>
   <script src="https://ajax.googleapis.com/ajax/libs/jquery/3.1.1/jquery.min.js"></script>
   <!-- Theme JavaScript -->
   <script src="js/mistphysics.js"></script>


### PR DESCRIPTION
This pull request moves the `container` classes up to the right parent block so it's correctly adding the left and right spacing. (There's no content restructuring).

Also prevents weirdly wide sections which made the text a bit difficult to track. We like narrow columns for text!

Some formatting to the page has also been applied by a prettifier in case you're wondering about the number of "changes"